### PR TITLE
fix: rewrite ensureEnvVars func

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -58,7 +58,7 @@ function ensureEnvVars() {
   const email = process.env.STREAM_SDK_TEST_ACCOUNT_EMAIL;
   const password = process.env.STREAM_SDK_TEST_ACCOUNT_PASSWORD;
   const otpSecret = process.env.STREAM_SDK_TEST_ACCOUNT_OTP_SECRET;
-  const missingEnvVars = [appUrl, email, password, otpSecret].some(envVar=> !envVar)
+  const missingEnvVars = [appUrl, email, password, otpSecret].some(envVar=> !envVar);
 
   if (missingEnvVars) {
     throw new Error('App url, email, password and OTP secret should be provided.');

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -58,7 +58,7 @@ function ensureEnvVars() {
   const email = process.env.STREAM_SDK_TEST_ACCOUNT_EMAIL;
   const password = process.env.STREAM_SDK_TEST_ACCOUNT_PASSWORD;
   const otpSecret = process.env.STREAM_SDK_TEST_ACCOUNT_OTP_SECRET;
-  const missingEnvVars = [appUrl, email, password, otpSecret].some(field=> !field)
+  const missingEnvVars = [appUrl, email, password, otpSecret].some(envVar=> !envVar)
 
   if (missingEnvVars) {
     throw new Error('App url, email, password and OTP secret should be provided.');

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -58,7 +58,7 @@ function ensureEnvVars() {
   const email = process.env.STREAM_SDK_TEST_ACCOUNT_EMAIL;
   const password = process.env.STREAM_SDK_TEST_ACCOUNT_PASSWORD;
   const otpSecret = process.env.STREAM_SDK_TEST_ACCOUNT_OTP_SECRET;
-  const missingEnvVars = [appUrl, email, password, otpSecret].some(envVar=> !envVar);
+  const missingEnvVars = [appUrl, email, password, otpSecret].some((envVar) => !envVar);
 
   if (missingEnvVars) {
     throw new Error('App url, email, password and OTP secret should be provided.');

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -54,12 +54,13 @@ async function googleAuth(options) {
 }
 
 function ensureEnvVars() {
-  const appUrl = process.env.STREAM_SDK_TEST_APP ?? '';
-  const email = process.env.STREAM_SDK_TEST_ACCOUNT_EMAIL ?? '';
-  const password = process.env.STREAM_SDK_TEST_ACCOUNT_PASSWORD ?? '';
-  const otpSecret = process.env.STREAM_SDK_TEST_ACCOUNT_OTP_SECRET ?? '';
+  const appUrl = process.env.STREAM_SDK_TEST_APP;
+  const email = process.env.STREAM_SDK_TEST_ACCOUNT_EMAIL;
+  const password = process.env.STREAM_SDK_TEST_ACCOUNT_PASSWORD;
+  const otpSecret = process.env.STREAM_SDK_TEST_ACCOUNT_OTP_SECRET;
+  const missingEnvVars = [appUrl, email, password, otpSecret].some(field=> !field)
 
-  if (appUrl == null || email == null || password == null || otpSecret == null) {
+  if (missingEnvVars) {
     throw new Error('App url, email, password and OTP secret should be provided.');
   }
 }


### PR DESCRIPTION
### 🔗 Issue Links
This issue occurred when I didn't fill in my env vars by skipping the readme step, our `ensureEnvVars func didn't catch it.
```
➜  stream-video-js git:(maestro-poc) ✗ stream-video-buddy auth                                              
⏳ Going through Google OAuth
node:internal/process/promises:279
            triggerUncaughtException(err, true /* fromPromise */);
            ^

page.goto: url: expected string, got undefined
    at googleAuth (/Users/stevegalili/.nvm/versions/node/v16.14.2/lib/node_modules/stream-video-buddy/lib/auth.js:25:14)
    at async VideoBuddyAuth.init (/Users/stevegalili/.nvm/versions/node/v16.14.2/lib/node_modules/stream-video-buddy/lib/auth.js:11:5)
```
### 🎯 Goal

Catch one or more empty env vars

### 📝 Summary

Detecting one or more falsey env vars

### 🛠 Implementation

- removing fallback when an env is empty will result in undefined instead of empty string, that step was unneded.
- check if one or more of the env array is empty by using `some` array api

### 🎨 Showcase

N/A

### 🧪 Manual Testing Notes

- remove one env var
- run auth command: `stream-video-buddy auth`
- see the error: "App url, email, password and OTP secret should be provided."

### ☑️ Contributor Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] This change follows zero ⚠️ policy (required)
- [x] This change should be manually QAed
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS)

### 🎁 Meme

<img src="https://media.makeameme.org/created/schnitzel-vscf5s.jpg" />